### PR TITLE
Migrate to OIDC trusted publishing for NuGet.org

### DIFF
--- a/.github/workflows/dotnet-cd.yml
+++ b/.github/workflows/dotnet-cd.yml
@@ -6,6 +6,10 @@ on:
     paths: 
       - src/**
   workflow_dispatch:
+permissions:
+  contents: write
+  packages: write
+  id-token: write
 jobs:
 
   test:
@@ -52,7 +56,8 @@ jobs:
 
 
   github-publish:
-    permissions: write-all
+    permissions:
+      packages: write
     needs: semantic-release
     name: Publish to Github
     runs-on: ubuntu-latest
@@ -66,10 +71,12 @@ jobs:
       with:
         dotnet-version: 7.0.x
     - name: Push Package to GitHub
-      run: dotnet nuget push --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/hughesjs/index.json" *.nupkg
+      run: dotnet nuget push --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/hughesjs/index.json" --skip-duplicate *.nupkg
 
 
   nuget-publish:
+    permissions:
+      id-token: write
     needs: semantic-release
     name: Publish to Nuget
     runs-on: ubuntu-latest
@@ -82,5 +89,10 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.x
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Push Package to Nuget
-      run: dotnet nuget push --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" *.nupkg
+      run: dotnet nuget push --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate *.nupkg


### PR DESCRIPTION
## Summary
Migrates NuGet.org publishing from API key-based authentication to OIDC trusted publishing, following the pattern from ArchonAnalysers.

## Changes
- Added workflow-level `id-token: write` permission for OIDC
- Added `NuGet/login@v1` action to obtain temporary API key
- Updated publish command to use OIDC-generated temporary key
- Added `--skip-duplicate` flag to prevent re-run errors
- Refined job permissions to principle of least privilege

## Prerequisites
✅ `NUGET_USER` secret already configured
⚠️ NuGet.org OIDC trusted publishing must be configured (user task)
⚠️ Do NOT remove `NUGET_KEY` secret until OIDC verified working

## Testing
After merge, verify package publishes successfully to both:
- NuGet.org: https://www.nuget.org/packages/CelesTrakSdk
- GitHub Packages: https://github.com/hughesjs?tab=packages

## Rollback
If OIDC fails, revert PR - old `NUGET_KEY` secret still available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release process with improved security measures for package publishing.
  * Implemented duplicate prevention in package deployment pipeline and refined permission controls for better operational safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->